### PR TITLE
feat - searchVocab

### DIFF
--- a/server/routes/vocab.js
+++ b/server/routes/vocab.js
@@ -4,6 +4,7 @@ import {
   vocabSuggestions,
   getCategories,
   displayVocab,
+  searchVocab,
 } from "../controllers/vocabController.js";
 
 const router = express.Router();
@@ -11,4 +12,5 @@ const router = express.Router();
 router.get("/", vocabSuggestions); // Use the controller function as the route handler
 router.get("/category", getCategories); // Use the controller function as the route handler
 router.get("/word/:id", displayVocab);
+router.get("/search", searchVocab);
 export default router;


### PR DESCRIPTION
## Search Vocabulary

### Endpoint
`GET /api/vocab/search`

### Description
This endpoint allows users to search for vocabulary terms based on a given query string. The search is performed within the vocabularies stored in the database, matching the beginning of vocabulary names (case-insensitive). The results are grouped by their respective categories and limited to the top 5 matches.

### Request

- **Query Parameters:**
  - `find` (optional): A string to search for vocabulary names that start with this value. If not provided, the search will return an empty array.

- **Example Request:**
  ```
  GET /api/vocab/search?find=ani
  ```

### Response

- **Status Code:**
  - `200 OK`: The request was successful, and the response contains an array of matched vocabulary terms.
  - `500 Internal Server Error`: The request failed due to a server error.

- **Response Body:**
  - An array of objects where each object represents a matched vocabulary term along with its category. The response will contain at most 5 items.

- **Example Response:**
  ```json
  [
    {
      "_id": "64f229b72c3d4e24b892f0e7",
      "name": "Animal",
      "category": "Biology"
    },
    {
      "_id": "64f229b72c3d4e24b892f0e8",
      "name": "Animation",
      "category": "Art"
    }
  ]
  ```

### Error Response

- **Status Code:**
  - `500 Internal Server Error`: An error occurred while processing the request.

- **Error Response Body:**
  ```json
  {
    "error": "Failed to fetch suggestions"
  }
  ```

### Aggregation Pipeline Details

The endpoint uses an aggregation pipeline with the following steps:
1. **$unwind**: Deconstructs the `vocabularies` array field from the documents to output a document for each element.
2. **$match**: Filters the documents based on the regex applied to the `vocabularies.name` field.
3. **$group**: Groups the matching documents by their `category` and selects the first matching vocabulary.
4. **$project**: Restructures the output to include the vocabulary's `_id`, `name`, and `category`.
5. **$limit**: Limits the output to a maximum of 5 documents.

### Notes
- The search is case-insensitive and matches the beginning of the vocabulary names.
- The results are grouped by category, ensuring that only one vocabulary from each category is returned.
